### PR TITLE
Update repository to repo.blackduck.com

### DIFF
--- a/src/main/resources/earlierversions/detect8.ps1
+++ b/src/main/resources/earlierversions/detect8.ps1
@@ -238,9 +238,9 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
 
             # If major version is 9 or less, than download from com/synopsys/integration location or else com/blackduck/integration
             if($detectVersionNumber -le 9) {
-                $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
+                $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
             } else {
-                $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/blackduck/integration/detect?properties=" + $DetectVersionKey
+                $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/blackduck/integration/detect?properties=" + $DetectVersionKey
             }
             $DetectSource = Receive-DetectSource -ProxyInfo $ProxyInfo -DetectVersionUrl $DetectVersionUrl -DetectVersionKey $DetectVersionKey
         }
@@ -251,9 +251,9 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
 
             # If major version is 9 or less, than download from com/synopsys/integration location or else com/blackduck/integration
             if($detectVersionNumber -le 9) {
-                $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
+                $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
             } else {
-                $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/blackduck/integration/detect/" + $DetectVersion + "/detect-" + $DetectVersion + ".jar"
+                $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/blackduck/integration/detect/" + $DetectVersion + "/detect-" + $DetectVersion + ".jar"
             }
         }
     }

--- a/src/main/resources/earlierversions/detect8.sh
+++ b/src/main/resources/earlierversions/detect8.sh
@@ -116,7 +116,7 @@ SCRIPT_VERSION=3.0.1
 
 echo "Detect Shell Script ${SCRIPT_VERSION}"
 
-DETECT_BINARY_REPO_URL=https://sig-repo.synopsys.com
+DETECT_BINARY_REPO_URL=https://repo.blackduck.com
 
 for i in $*; do
   if [[ $i == --blackduck.hub.password=* ]]; then

--- a/src/main/resources/earlierversions/detect9.ps1
+++ b/src/main/resources/earlierversions/detect9.ps1
@@ -238,9 +238,9 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
 
             # If major version is 9 or less, than download from com/synopsys/integration location or else com/blackduck/integration
             if($detectVersionNumber -le 9) {
-                $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
+                $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
             } else {
-                $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/blackduck/integration/detect?properties=" + $DetectVersionKey
+                $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/blackduck/integration/detect?properties=" + $DetectVersionKey
             }
             $DetectSource = Receive-DetectSource -ProxyInfo $ProxyInfo -DetectVersionUrl $DetectVersionUrl -DetectVersionKey $DetectVersionKey
         }
@@ -251,9 +251,9 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
 
             # If major version is 9 or less, than download from com/synopsys/integration location or else com/blackduck/integration
             if($detectVersionNumber -le 9) {
-                $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
+                $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
             } else {
-                $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/blackduck/integration/detect/" + $DetectVersion + "/detect-" + $DetectVersion + ".jar"
+                $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/blackduck/integration/detect/" + $DetectVersion + "/detect-" + $DetectVersion + ".jar"
             }
         }
     }

--- a/src/main/resources/earlierversions/detect9.sh
+++ b/src/main/resources/earlierversions/detect9.sh
@@ -114,7 +114,7 @@ SCRIPT_VERSION=3.1.0
 
 echo "Detect Shell Script ${SCRIPT_VERSION}"
 
-DETECT_BINARY_REPO_URL=https://sig-repo.synopsys.com
+DETECT_BINARY_REPO_URL=https://repo.blackduck.com
 
 for i in $*; do
   if [[ $i == --blackduck.hub.password=* ]]; then


### PR DESCRIPTION
Update repository to repo.blackduck.com in older scripts.
This is the new location from which the Detect jar will be downloaded.